### PR TITLE
NF: OCT image quality metrics

### DIFF
--- a/reflectance/image_quality.m
+++ b/reflectance/image_quality.m
@@ -27,9 +27,6 @@ function iq = image_quality(I, metric, varargin)
 %   
 %   'seg'            Struct with segmentation used in 'snr','psnr','cnr'.
 %
-%   'scale_z'        Axial resolution. Used in 'snr_approx' to approximate
-%                    the number of pixels of the retina.
-%
 %  
 %   Output arguments:
 %  

--- a/reflectance/image_quality.m
+++ b/reflectance/image_quality.m
@@ -1,0 +1,102 @@
+function metric = image_quality(I, scanner)
+%IMAGE_QUALITY Compute an image quality metric
+%
+%   metric = image_quality(I)
+%   Compute the maximum tissue contrast index (mTCI) from each bscan [1].
+%
+%   Input arguments:
+%  
+%   'I'              2D or 3D matrix with bscan data. If 3D data the 3rd
+%                    dimension is assumed to be the bscan index.
+%            
+%   'scanner'        String definint the OCT scanner.
+%                    Options: 'Cirrus','RTVue',Spectralis','3D-OCT-1000'
+%                    If not provided an arbitrary value will be used.
+%
+%
+%  
+%   Output arguments:
+%  
+%   'metric'         Image quality metric.        
+%  
+%
+%
+%   References
+%   ----------
+%   [1] Huang, Signal Quality Assessment of Retinal Optical Coherence 
+%   Tomography Images, IOVS, 2012. 
+%   https://dx.doi.org/10.1167%2Fiovs.11-8755
+%
+%
+%   Example
+%   ---------      
+%   % Example description
+%
+%     [~,
+%     [GLCMS,SI] = graycomatrix(I,'NumLevels',9,'G',[])
+%     
+%
+%  
+%   David Romero-Bascones, dromero@mondragon.edu
+%   Biomedical Engineering Department, Mondragon Unibertsitatea, 2022
+
+if nargin == 1
+    scanner = 'unknown';
+end
+
+switch scanner
+    case 'Cirrus'
+        cN1Bs = 0.4;
+    case 'RTVue'
+        cN1Bs = 0.55;
+    case 'Spectralis'
+        cN1Bs = 0.45;
+    case '3D-OCT-1000'
+        cN1Bs = 0.5;
+    otherwise
+        warning('Unknown scanner. Using 0.45 as an arbitrary default');
+        cN1Bs = 0.45;
+end
+
+if ndims(I) == 3
+    metric = nan(1, n_bscan);
+    for i_bscan=1:n_bscan
+        metric(i_bscan) = compute_mTCI(I(:,:,i_bscan), cN1Bs);    
+    end
+    return;
+end
+
+metric = compute_mTCI(I, cN1Bs);
+
+function mTCI = compute_mTCI(I, cN1Bs)
+I = I(:);
+N = length(I);
+
+h = histogram(I);
+y_pdf = h.Values;
+x_pdf = h.BinEdges(1:end-1) + h.BinWidth/2;
+
+[y_cdf, x_cdf] = ecdf(I);
+
+% Get N1 (histogram mode)
+[yN1, ind_N1] = max(y_pdf);
+N1 = x_pdf(ind_N1(1));
+
+% Compute cN1s
+ind_N1s = find(y_pdf >= 0.95*yN1);
+N1s = x_pdf(ind_N1s(1));
+cN1s = sum(I <= N1s)/N;
+
+% Compute cN2
+cN2 = cN1s*0.999/cN1Bs;
+
+% Compute N2
+ind_N2 = find(y_cdf >= cN2);
+N2 = x_cdf(ind_N2(1));
+
+% Compute N3
+ind_N3 = find(y_cdf >= 0.999);
+N3 = x_cdf(ind_N3(1));
+
+% Compute mTCI
+mTCI = (N3 - N1)/(N2 - N1);

--- a/reflectance/image_quality.m
+++ b/reflectance/image_quality.m
@@ -1,23 +1,35 @@
-function metric = image_quality(I, scanner)
+function iq = image_quality(I, metric, varargin)
 %IMAGE_QUALITY Compute an image quality metric
 %
 %   metric = image_quality(I)
-%   Compute the maximum tissue contrast index (mTCI) from each bscan [1].
+%   Compute an image quality metric for each bscan in I. Supported options
+%   are signal to noise ratio (snr) and maximum tissue contrast index 
+%   (mTCI) [1].
 %
 %   Input arguments:
 %  
 %   'I'              2D or 3D matrix with bscan data. If 3D data the 3rd
 %                    dimension is assumed to be the bscan index.
 %            
-%   'scanner'        String definint the OCT scanner.
+%   'metric'         Metric used to compute image quality. Accepted options
+%                    Options: 'snr','snr_approx','mTCI'
+%                    Default: 'mTCI'
+%
+%   Optional input arguments (varargin):
+%
+%   'scanner'        When using mTCI. String defining the OCT scanner.
 %                    Options: 'Cirrus','RTVue',Spectralis','3D-OCT-1000'
 %                    If not provided an arbitrary value will be used.
+%   
+%   'seg'            Segmentation structure. When using 'snr'.
 %
+%   'scale_z'        Axial resolution. Used in 'snr_approx' to approximate
+%                    the number of pixels of the retina.
 %
 %  
 %   Output arguments:
 %  
-%   'metric'         Image quality metric.        
+%   'iq'         Image quality metric.        
 %  
 %
 %
@@ -30,57 +42,112 @@ function metric = image_quality(I, scanner)
 %
 %   Example
 %   ---------      
-%   % Example description
+%   % Compute mTCI for a whole volume
 %
-%     [~,
-%     [GLCMS,SI] = graycomatrix(I,'NumLevels',9,'G',[])
-%     
+%   [~, ~, bscan] = read_vol(file);
+%   mTCI = image_quality(bscan, 'Spectralis');
 %
 %  
 %   David Romero-Bascones, dromero@mondragon.edu
 %   Biomedical Engineering Department, Mondragon Unibertsitatea, 2022
 
 if nargin == 1
-    scanner = 'unknown';
+    metric = 'mTCI';
 end
 
-switch scanner
-    case 'Cirrus'
-        cN1Bs = 0.4;
-    case 'RTVue'
-        cN1Bs = 0.55;
-    case 'Spectralis'
-        cN1Bs = 0.45;
-    case '3D-OCT-1000'
-        cN1Bs = 0.5;
+if nargin > 3
+    error('This function accepts a maximum of 3 arguments');
+end
+
+I = double(I);
+% I(I==0) = nan; % Spectralis data has a peak in zero. The detection level
+% is above the real 0 and therefore many values are mapped to 0 (ceil).
+
+switch metric
+    case 'mTCI'
+        if nargin == 3
+            scanner = varargin{1};            
+        else
+            scanner = 'unknown';
+        end
+        
+        % Get noise profiling defaults depending on scanner
+        switch scanner
+            case 'Cirrus'
+                cN1Bs = 0.4;
+            case 'RTVue'
+                cN1Bs = 0.55;
+            case 'Spectralis'
+                cN1Bs = 0.45;
+            case '3D-OCT-1000'
+                cN1Bs = 0.5;
+            otherwise
+                warning(['Unknown scanner. Valid options: Cirrus, RTVue, Spectralis',...
+                    ', 3D-OCT-1000. Using 0.45 as an arbitrary default.']);
+                cN1Bs = 0.45;
+        end
+        
+        % Metric computation
+        if ismatrix(I)
+            iq = compute_mTCI(I, cN1Bs);
+        elseif ndims(I) == 3
+            n_bscan = size(I, 3);
+            iq = nan(1, n_bscan);
+            for i_bscan=1:n_bscan
+                iq(i_bscan) = compute_mTCI(I(:,:,i_bscan), cN1Bs);    
+            end
+        end
+        
+    case 'snr'
+        if nargin < 3
+            error('snr requires segmentation data as an input');
+        end        
+        seg = varargin{1};
+        
+        % SNR computation
+        if ismatrix(I)
+            iq = compute_snr(I, seg.ILM, seg.BM);
+        elseif ndims(I) == 3
+            n_bscan = size(I, 3);
+            iq = nan(1, n_bscan);
+            for i_bscan=1:n_bscan
+                ilm = seg.ILM(i_bscan,:);
+                bm = seg.BM(i_bscan,:);
+                iq(i_bscan) = compute_snr(I(:,:,i_bscan), ilm, bm);    
+            end
+        end
+        
     otherwise
-        warning('Unknown scanner. Using 0.45 as an arbitrary default');
-        cN1Bs = 0.45;
+        error("Unknown metric. Valid options are: 'mTCI', 'snr'");
 end
 
-if ndims(I) == 3
-    metric = nan(1, n_bscan);
-    for i_bscan=1:n_bscan
-        metric(i_bscan) = compute_mTCI(I(:,:,i_bscan), cN1Bs);    
-    end
-    return;
-end
+function snr = compute_snr(I, ilm, bm)
 
-metric = compute_mTCI(I, cN1Bs);
+% Efficiently compute the retinal mask
+idx = repmat(1:size(I,1),size(I,2),1)';
+mask_in = (idx >= ilm) & (idx <= bm);
+
+signal = nanmean(I(mask_in));
+noise = nanmean(I(~mask_in));
+snr = signal/noise;
 
 function mTCI = compute_mTCI(I, cN1Bs)
-I = I(:);
+I = I(~isnan(I));
+
 N = length(I);
 
-h = histogram(I);
-y_pdf = h.Values;
-x_pdf = h.BinEdges(1:end-1) + h.BinWidth/2;
+% Get pdf estimation from histogram
+[h, edges] = histcounts(I,200);
+y_pdf = h/N;
+x_pdf = (edges(1:end-1) + edges(2:end))/2;
 
+% Get cdf estimation
 [y_cdf, x_cdf] = ecdf(I);
 
 % Get N1 (histogram mode)
 [yN1, ind_N1] = max(y_pdf);
 N1 = x_pdf(ind_N1(1));
+% cN1 = sum(I <= N1)/N;
 
 % Compute cN1s
 ind_N1s = find(y_pdf >= 0.95*yN1);
@@ -90,13 +157,35 @@ cN1s = sum(I <= N1s)/N;
 % Compute cN2
 cN2 = cN1s*0.999/cN1Bs;
 
+if cN2 > 1
+    error("Unable to compute mTCI due to a cN2 threshold > 1.");
+end
+
 % Compute N2
 ind_N2 = find(y_cdf >= cN2);
+
 N2 = x_cdf(ind_N2(1));
 
 % Compute N3
-ind_N3 = find(y_cdf >= 0.999);
+cN3 = 0.999;
+ind_N3 = find(y_cdf >= cN3);
 N3 = x_cdf(ind_N3(1));
 
 % Compute mTCI
 mTCI = (N3 - N1)/(N2 - N1);
+
+% subplot(121);hold on;
+% max_val = max(y_pdf);
+% plot(x_pdf,y_pdf,'k','LineWidth',1.5);
+% plot([N1 N1],[0 max_val],'--r'); text(N1,max_val/2,'N1');
+% plot([N1s N1s],[0 max_val],'--r');text(N1s,max_val/2,'N1s');
+% plot([N2 N2],[0 max_val],'--g');text(N2,max_val/2,'N2');
+% plot([N3 N3],[0 max_val],'--m');text(N3,max_val/2,'N3');
+% 
+% subplot(122);hold on;
+% plot(x_cdf,y_cdf,'k');
+% plot([N1 N1 0],[0 cN1s cN1s],'--r');
+% plot([N2 N2 0],[0 cN2 cN2],'--g');
+% plot([N3 N3 0],[0 cN3 cN3],'--m');
+% 
+% disp('');

--- a/test/test_reflectance.m
+++ b/test/test_reflectance.m
@@ -87,7 +87,7 @@ file = '../data/raster.vol';
 [header, seg, bscan] = read_vol(file,'full_header');
 
 mTCI = image_quality(bscan,'mTCI','Spectralis');
-snr = image_quality(bscan,'snr',seg);
+snr = image_quality(bscan,'cnr',seg);
 
 subplot(121);
 scatter(header.quality, mTCI, 'filled'); hold on;
@@ -105,3 +105,5 @@ folder = '../data_private/example_tabs';
 [header, seg, bscan] = read_tabs(folder);
 mTCI = image_quality(bscan,'mTCI','3D-OCT-1000');
 snr = image_quality(bscan,'snr',seg);
+
+scatter(mTCI, snr);

--- a/test/test_reflectance.m
+++ b/test/test_reflectance.m
@@ -80,3 +80,28 @@ subplot(131);imagesc(stacked.RNFL);axis off;title('RNFL');
 subplot(132);imagesc(stacked.GCIP);axis off; title('GCIP');
 subplot(133);imagesc(stacked.RPE);axis off; title('RPE');
 colormap(gray);
+
+%% Image Quality (Spectralis)
+clc;clearvars;close all;
+file = '../data/raster.vol';
+[header, seg, bscan] = read_vol(file,'full_header');
+
+mTCI = image_quality(bscan,'mTCI','Spectralis');
+snr = image_quality(bscan,'snr',seg);
+
+subplot(121);
+scatter(header.quality, mTCI, 'filled'); hold on;
+xlabel('Spectralis');
+ylabel('mTCI');
+
+subplot(122);
+scatter(header.quality, snr, 'filled');
+xlabel('Spectralis');
+ylabel('SNR');
+
+%% Image Quality (Topcon)
+clc;clearvars;close all;
+folder = '../data_private/example_tabs';
+[header, seg, bscan] = read_tabs(folder);
+mTCI = image_quality(bscan,'mTCI','3D-OCT-1000');
+snr = image_quality(bscan,'snr',seg);


### PR DESCRIPTION
Adds a function to compute basic SNR-related image quality metrics.

Future improvements:
- Extend docstrings (more info on units, use cases...)
- Implement segmentation-independent metrics to capture empty images and be robust to segmentation errors. (Something similar to mTCI but more intuitive ideally)